### PR TITLE
Give anti-evil-maid.sh some love

### DIFF
--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -22,16 +22,16 @@ function message() {
 
 
 if [ -d /antievilmaid ] ; then
-	info "/antievilmaid already exists, skipping..."
-	exit 0
+    info "/antievilmaid already exists, skipping..."
+    exit 0
 fi
 
-info "Waiting for antievilmaid boot device to become avilable..."
+info "Waiting for antievilmaid boot device to become available..."
 while ! [ -b /dev/antievilmaid ]; do
-	sleep 0.1
+    sleep 0.1
 done
 
-info "Mouting the antievilmaid boot device..."
+info "Mounting the antievilmaid boot device..."
 mkdir /antievilmaid
 mount /dev/antievilmaid /antievilmaid
 
@@ -95,7 +95,7 @@ if ! getarg rd.antievilmaid.dontforcestickremoval; then
 
     message "Please remove your Anti Evil Maid stick and continue the boot process only if your secret appears on the screen..."
     while [ -b /dev/antievilmaid ]; do
-	    sleep 0.1
+        sleep 0.1
     done
 
     if [ -x /bin/plymouth ]; then

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -9,8 +9,7 @@
 
 
 . /lib/dracut-lib.sh
-
-command -v ask_for_password >/dev/null || . /lib/dracut-crypt-lib.sh
+type ask_for_password >/dev/null 2>&1 || . /lib/dracut-crypt-lib.sh
 
 shopt -s expand_aliases
 if type plymouth >/dev/null 2>&1; then

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -57,16 +57,16 @@ mkdir -p /var/lib/tpm/
 cp "$MNT/antievilmaid/system.data" /var/lib/tpm/
 tcsd
 
-TPM_ARGS="-o $UNSEALED_SECRET"
-if ! getarg rd.antievilmaid.asksrkpass; then
-    info "Using default TPM SRK unseal password"
-    TPM_ARGS="$TPM_ARGS -z"
-fi
-
-message "Attempting to unseal the secret from the TPM..."
-message ""
-
 if [ -f "$SEALED_SECRET" ] ; then
+    TPM_ARGS="-o $UNSEALED_SECRET"
+    if ! getarg rd.antievilmaid.asksrkpass; then
+        info "Using default TPM SRK unseal password"
+        TPM_ARGS="$TPM_ARGS -z"
+    fi
+
+    message "Attempting to unseal the secret from the TPM..."
+    message ""
+
     UNSEAL_CMD="tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET"
     if getarg rd.antievilmaid.asksrkpass; then
         # we set tries to 1 as some TCG 1.2 TPMs start "protecting themselves against

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -68,10 +68,11 @@ message ""
 
 if [ -f "$SEALED_SECRET" ] ; then
     UNSEAL_CMD="tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET"
-    #we set tries to 1 as some TCG 1.2 TPMs start "protecting themselves against dictionary attacks" when there's more than 1 try within a short time... -_- (TCG 2 fixes that)
     if getarg rd.antievilmaid.asksrkpass; then
+        # we set tries to 1 as some TCG 1.2 TPMs start "protecting themselves against
+        # dictionary attacks" when there's more than 1 try within a short time... -_-
+        # (TCG 2 fixes that)
         ask_for_password --cmd "$UNSEAL_CMD" --prompt "TPM SRK unseal password" --tries 1
-            #--tty-echo-off
     else
         $UNSEAL_CMD
     fi

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -67,12 +67,13 @@ message "Attempting to unseal the secret from the TPM..."
 message ""
 
 if [ -f "$SEALED_SECRET" ] ; then
+    UNSEAL_CMD="tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET"
     #we set tries to 1 as some TCG 1.2 TPMs start "protecting themselves against dictionary attacks" when there's more than 1 try within a short time... -_- (TCG 2 fixes that)
     if getarg rd.antievilmaid.asksrkpass; then
-        ask_for_password --cmd "tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET" --prompt "TPM SRK unseal password" --tries 1
+        ask_for_password --cmd "$UNSEAL_CMD" --prompt "TPM SRK unseal password" --tries 1
             #--tty-echo-off
     else
-        tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET
+        $UNSEAL_CMD
     fi
     message "$(cat "$UNSEALED_SECRET" 2>/dev/null)"
 else

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Anti Evil Maid for dracut by Invisible Things Lab
 # Copyright (C) 2010 Joanna Rutkowska <joanna@invisiblethingslab.com>
@@ -12,14 +12,15 @@
 
 command -v ask_for_password >/dev/null || . /lib/dracut-crypt-lib.sh
 
+PLYMOUTH_MESSAGES=()
 function message() {
     if type plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null; then
-        /bin/plymouth message --text="$1"
+        plymouth message --text="$1"
+        PLYMOUTH_MESSAGES+=("$1")
     else
         echo "$1"
     fi
 }
-
 
 if [ -d /antievilmaid ] ; then
     info "/antievilmaid already exists, skipping..."
@@ -99,16 +100,10 @@ if ! getarg rd.antievilmaid.dontforcestickremoval; then
     done
 
     if [ -x /bin/plymouth ]; then
-        # hide the secret
-        /bin/plymouth hide-message --text="`cat /tmp/unsealed-secret.txt 2> /dev/null`"
-        # hide remaining messages
-        /bin/plymouth hide-message --text="Attempting to unseal the secret passphrase from the TPM..."
-        /bin/plymouth hide-message --text=""
-        /bin/plymouth hide-message --text=""
-        /bin/plymouth hide-message --text="Continue the boot process only if the secret above is correct!"
-        /bin/plymouth hide-message --text="Continue the boot process only if the secret image next to the password prompt is correct!"
-        /bin/plymouth hide-message --text=""
-        /bin/plymouth hide-message --text="Please remove your Anti Evil Maid stick and continue the boot process only if your secret appears on the screen..."
+        # hide the secret and our other messages
+        for m in "${PLYMOUTH_MESSAGES[@]}"; do
+            plymouth hide-message --text="$m"
+        done
         /bin/plymouth unpause-progress
     fi
 fi

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -93,14 +93,12 @@ else
 fi
 
 if getarg rd.antievilmaid.png_secret; then
-    message ""
-    message "Continue the boot process only if the secret image next to the password prompt is correct!"
-    message ""
+    WHERE="next to the prompt for it"
 else
-    message ""
-    message "Continue the boot process only if the secret above is correct!"
+    WHERE="above"
     message ""
 fi
+message "Never enter your disk password unless the secret $WHERE is correct!"
 
 plymouth_maybe pause-progress
 if getarg rd.antievilmaid.dontforcestickremoval; then

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -76,9 +76,20 @@ if [ -f "$SEALED_SECRET" ] ; then
     else
         $UNSEAL_CMD
     fi
-    message "$(cat "$UNSEALED_SECRET" 2>/dev/null)"
 else
     message "No data to unseal. Do not forget to generate a ${SEALED_SECRET##*/}"
+fi
+
+info "Unmounting the antievilmaid device..."
+umount "$MNT"
+
+if getarg rd.antievilmaid.png_secret; then
+    # Verify if the unsealed PNG secret seems valid and replace the lock icon
+    if file "$UNSEALED_SECRET" 2>/dev/null | grep -q PNG; then
+        cp "$UNSEALED_SECRET" "$PLYMOUTH_THEME_UNSEALED_SECRET"
+    fi
+else
+    message "$(cat "$UNSEALED_SECRET" 2>/dev/null)"
 fi
 
 if getarg rd.antievilmaid.png_secret; then
@@ -89,15 +100,6 @@ else
     message ""
     message "Continue the boot process only if the secret above is correct!"
     message ""
-fi
-info "Unmounting the antievilmaid device..."
-umount "$MNT"
-
-# Verify if the unsealed PNG secret seems valid and replace the lock icon
-if getarg rd.antievilmaid.png_secret; then
-    if file "$UNSEALED_SECRET" 2>/dev/null | grep -q PNG; then
-        cp "$UNSEALED_SECRET" "$PLYMOUTH_THEME_UNSEALED_SECRET"
-    fi
 fi
 
 plymouth_maybe pause-progress

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -59,17 +59,17 @@ tcsd
 
 TPM_ARGS="-o $UNSEALED_SECRET"
 if ! getarg rd.antievilmaid.asksrkpass; then
-    info "Using default SRK password"
+    info "Using default TPM SRK unseal password"
     TPM_ARGS="$TPM_ARGS -z"
 fi
 
-message "Attempting to unseal the secret passphrase from the TPM..."
+message "Attempting to unseal the secret from the TPM..."
 message ""
 
 if [ -f "$SEALED_SECRET" ] ; then
     #we set tries to 1 as some TCG 1.2 TPMs start "protecting themselves against dictionary attacks" when there's more than 1 try within a short time... -_- (TCG 2 fixes that)
     if getarg rd.antievilmaid.asksrkpass; then
-        ask_for_password --cmd "tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET" --prompt "TPM Unseal Password" --tries 1
+        ask_for_password --cmd "tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET" --prompt "TPM SRK unseal password" --tries 1
             #--tty-echo-off
     else
         tpm_unsealdata $TPM_ARGS -i $SEALED_SECRET

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -97,18 +97,23 @@ if getarg rd.antievilmaid.png_secret; then
     fi
 fi
 
-if ! getarg rd.antievilmaid.dontforcestickremoval; then
-    # Pause progress till the user remove the stick
-    plymouth_maybe pause-progress
-
-    message "Please remove your Anti Evil Maid stick and continue the boot process only if your secret appears on the screen..."
+plymouth_maybe pause-progress
+if getarg rd.antievilmaid.dontforcestickremoval; then
+    if ! getarg rd.antievilmaid.png_secret; then
+        message "Press <SPACE> to continue..."
+        plymouth_maybe watch-keystroke --keys=" "
+    fi
+else
+    message "Remove your Anti Evil Maid stick to continue..."
     while [ -b /dev/antievilmaid ]; do
         sleep 0.1
     done
+fi
+plymouth_maybe unpause-progress
 
+if ! getarg rd.antievilmaid.dontforcestickremoval || ! getarg rd.antievilmaid.png_secret; then
     for m in "${PLYMOUTH_MESSAGES[@]}"; do
         plymouth_maybe hide-message --text="$m"
     done
-    plymouth_maybe unpause-progress
 fi
 rm -f /tmp/unsealed-secret.txt

--- a/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
+++ b/dracut-antievilmaid/90anti-evil-maid/anti-evil-maid.sh
@@ -12,6 +12,13 @@
 
 command -v ask_for_password >/dev/null || . /lib/dracut-crypt-lib.sh
 
+shopt -s expand_aliases
+if type plymouth >/dev/null 2>&1; then
+     alias plymouth_maybe=plymouth
+else
+     alias plymouth_maybe=:
+fi
+
 PLYMOUTH_MESSAGES=()
 function message() {
     if type plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null; then
@@ -92,19 +99,16 @@ fi
 
 if ! getarg rd.antievilmaid.dontforcestickremoval; then
     # Pause progress till the user remove the stick
-    [ -x /bin/plymouth ] && /bin/plymouth pause-progress
+    plymouth_maybe pause-progress
 
     message "Please remove your Anti Evil Maid stick and continue the boot process only if your secret appears on the screen..."
     while [ -b /dev/antievilmaid ]; do
         sleep 0.1
     done
 
-    if [ -x /bin/plymouth ]; then
-        # hide the secret and our other messages
-        for m in "${PLYMOUTH_MESSAGES[@]}"; do
-            plymouth hide-message --text="$m"
-        done
-        /bin/plymouth unpause-progress
-    fi
+    for m in "${PLYMOUTH_MESSAGES[@]}"; do
+        plymouth_maybe hide-message --text="$m"
+    done
+    plymouth_maybe unpause-progress
 fi
 rm -f /tmp/unsealed-secret.txt


### PR DESCRIPTION
- Clear the secret etc. even in the `dontforcestickremoval` case (when it makes sense)
- More precise and consistent user instructions
- Factor out redundant code, centralize repeated hardcoded values to variables, etc.

I've noticed that there's a bug with `asksrkpass` (at least on Qubes 3.0 RC1): I need to enter my _disk_ password twice. But that bug was not introduced by these commits, just so you know. :)
