### PR TITLE
Reinsert "udevadm trigger/settle" against duplicate label attacks

### DIFF
--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-unseal
@@ -26,6 +26,9 @@ plymouth_message() {
 
 # find AEM device
 
+udevadm trigger
+udevadm settle
+
 GLOB=/dev/disk/by-label/$LABEL_PREFIX*
 MSG="Waiting for $GLOB to be connected..."
 

--- a/anti-evil-maid/sbin/anti-evil-maid-install
+++ b/anti-evil-maid/sbin/anti-evil-maid-install
@@ -78,6 +78,7 @@ if [ -z "$(getluksuuids)" ]; then
     exit 1
 fi
 
+
 # examine device
 
 BOOT_MAJMIN=$(mountpoint -d "$BOOT_DIR") || BOOT_MAJMIN=


### PR DESCRIPTION
Sorry, I shouldn't have taken those two lines out. Even with the busy loop they're still beneficial to make the timing tighter.
