### PR TITLE
During late boot, start tcsd.service only when needed

### DIFF
--- a/anti-evil-maid/README
+++ b/anti-evil-maid/README
@@ -43,7 +43,7 @@ PCR-04: 93 33 4E 81 A6 9C 80 54 D6 87 C7 FD 76 7C 6F 4C 70 FC C6 73
 3) Take ownership of your TPM. This, among other things, would generate
 the TPM SRK key used for sealing process:
 
-# systemctl start tcsd
+# systemctl restart tcsd
 # tpm_takeownership -y -z
 
 You may want to use non-default password for the SRK key (see the discussion in the article referenced above), certainly if you want to save the sealed secrets to your internal boot partition. In that case you SHOULD NOT pass the '-z' argument to tpm_takeownership.

--- a/anti-evil-maid/README
+++ b/anti-evil-maid/README
@@ -43,6 +43,7 @@ PCR-04: 93 33 4E 81 A6 9C 80 54 D6 87 C7 FD 76 7C 6F 4C 70 FC C6 73
 3) Take ownership of your TPM. This, among other things, would generate
 the TPM SRK key used for sealing process:
 
+# systemctl start tcsd
 # tpm_takeownership -y -z
 
 You may want to use non-default password for the SRK key (see the discussion in the article referenced above), certainly if you want to save the sealed secrets to your internal boot partition. In that case you SHOULD NOT pass the '-z' argument to tpm_takeownership.

--- a/anti-evil-maid/anti-evil-maid.spec
+++ b/anti-evil-maid/anti-evil-maid.spec
@@ -7,7 +7,8 @@ Name:		%{name}
 Version:	%{version}
 Release:	1%{?dist}
 Summary:    	Anti Evil Maid for initramfs-based systems.
-Requires:	dracut parted tboot tpm-tools tpm-extra trousers-changer systemd >= 208-19
+Requires:	dracut grub2-tools parted tboot tpm-tools tpm-extra trousers-changer systemd >= 208-19
+Requires(post):	dracut grub2-tools tboot systemd
 Obsoletes:	anti-evil-maid-dracut
 Vendor:		Invisible Things Lab
 License:	GPL

--- a/anti-evil-maid/anti-evil-maid.spec
+++ b/anti-evil-maid/anti-evil-maid.spec
@@ -65,7 +65,6 @@ systemctl daemon-reload
 %post
 chmod -x %tboot_grub
 %refresh
-systemctl start tcsd
 
 %postun
 if [ "$1" = 0 ]; then

--- a/anti-evil-maid/sbin/anti-evil-maid-seal
+++ b/anti-evil-maid/sbin/anti-evil-maid-seal
@@ -1,5 +1,13 @@
 #!/bin/sh -e
 
+# Listing tcsd.service in anti-evil-maid-seal.service's Requires= and After=
+# would cause it to always be started (even when not booting in AEM mode or
+# when sealing is unnecessary) due to the way systemd evaluates conditions.
+# Putting the systemctl command in ExecStartPre= is also insufficient: The user
+# might want to run this script manually after changing the secret(s).
+
+systemctl start tcsd
+
 alias plymouth_message="plymouth message --text"
 . anti-evil-maid-lib
 trap 'rm -rf "$CACHE_DIR"' EXIT

--- a/anti-evil-maid/systemd/system/anti-evil-maid-seal.service
+++ b/anti-evil-maid/systemd/system/anti-evil-maid-seal.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Anti Evil Maid sealing
 DefaultDependencies=false
-Requires=local-fs.target tcsd.service
-After=local-fs.target tcsd.service plymouth-start.service
+Requires=local-fs.target
+After=local-fs.target plymouth-start.service
 Before=basic.target
 ConditionKernelCommandLine=rd.antievilmaid
 ConditionPathIsDirectory=/run/anti-evil-maid

--- a/trousers-changer/sbin/tcsd_changer_migrate
+++ b/trousers-changer/sbin/tcsd_changer_migrate
@@ -23,22 +23,7 @@ if [ -e "$TPM_MIGRATE_DIR" ]; then
     exit 1
 fi
 
-if systemctl --quiet is-active tcsd; then
-    alias was_running=true
-else
-    alias was_running=false
-fi
-
-systemctl --quiet --runtime mask tcsd
-systemctl stop tcsd
-
 mv "$TPM_DIR" "$TPM_MIGRATE_DIR"
 tcsd_changer_identify
 find "$TPM_MIGRATE_DIR" -mindepth 1 -maxdepth 1 -exec mv {} "$TPM_DIR"/ \;
 rmdir "$TPM_MIGRATE_DIR"
-
-systemctl --quiet --runtime unmask tcsd
-systemctl daemon-reload  # pick up the tcsd.service.d snippet
-if was_running; then
-    systemctl start tcsd
-fi

--- a/trousers-changer/systemd/system/tcsd.service.d/trousers-changer.conf
+++ b/trousers-changer/systemd/system/tcsd.service.d/trousers-changer.conf
@@ -1,2 +1,3 @@
 [Service]
+ExecStartPre=/sbin/tcsd_changer_migrate
 ExecStartPre=/sbin/tcsd_changer_identify

--- a/trousers-changer/trousers-changer.spec
+++ b/trousers-changer/trousers-changer.spec
@@ -25,12 +25,10 @@ cp -r systemd $RPM_BUILD_ROOT/usr/lib
 /sbin/tpm_id
 /sbin/tcsd_changer_identify
 /sbin/tcsd_changer_migrate
-/usr/lib/systemd/system/tcsd.service.d/tcsd_changer_identify.conf
+/usr/lib/systemd/system/tcsd.service.d/trousers-changer.conf
 
 %post
-if [ "$1" = 1 ]; then
-    tcsd_changer_migrate
-fi
+systemctl daemon-reload
 
 %postun
 if [ "$1" = 0 ]; then

--- a/trousers-changer/trousers-changer.spec
+++ b/trousers-changer/trousers-changer.spec
@@ -8,6 +8,7 @@ Version:	%{version}
 Release:	1%{?dist}
 Summary:    	tcsd wrapper for portable installations
 Requires:	trousers tpm-tools systemd
+Requires(post):	systemd
 Vendor:		Invisible Things Lab
 License:	GPL
 URL:		http://www.qubes-os.org


### PR DESCRIPTION
This speeds up the boot process a few seconds in the normal case, where
resealing is not needed.

It should also make it safe to ship the AEM packages in dom0 by default;
the GRUB option is shown only if /aem exists on the boot partition since
https://github.com/QubesOS/qubes-antievilmaid/commit/0786b3531468abbdc37f92656396928f74296799
