### PR TITLE
anti-evil-maid-check-mount-devs: check recursively for encrypted devices

### DIFF
--- a/anti-evil-maid/90anti-evil-maid/anti-evil-maid-check-mount-devs
+++ b/anti-evil-maid/90anti-evil-maid/anti-evil-maid-check-mount-devs
@@ -6,14 +6,26 @@ set -e
 shopt -s expand_aliases
 
 function check_device() {
+    local sysfs_path recursion_limit dm_name dm_target slave
     sysfs_path="$1"
+    recursion_limit="${2:-10}"
 
     if [ -r "$sysfs_path/dm/name" ]; then
         dm_name="`cat $sysfs_path/dm/name`"
         dm_target="`dmsetup table "$dm_name" | cut -d ' ' -f 3`"
         # This also ensures that the dm table have only single entry
-        test "$dm_target" = "crypt"
-        return $?
+        if [ "$dm_target" = "crypt" ]; then
+            return 0
+        elif [ -n "`ls -A "$sysfs_path"/slaves`" ] && [ "$recursion_limit" -gt 0 ]; then
+            for slave in "$sysfs_path"/slaves/*; do
+                if ! check_device "$slave" "$(( recursion_limit - 1 ))"; then
+                    return 1
+                fi
+            done
+            return 0
+        else
+            return 1
+        fi
     else
         return 1
     fi
@@ -34,25 +46,15 @@ fi
 root_devid=`lsblk -dnr -o MAJ:MIN $root_dev`
 
 if ! check_device /sys/dev/block/$root_devid; then
-    if [ -n "`ls -A /sys/dev/block/$root_devid/slaves`" ]; then
-        for slave in /sys/dev/block/$root_devid/slaves/*; do
-            if ! check_device $slave; then
-                die "AEM: (bogus?) root device found not encrypted!"
-            fi
-        done
-    else
-        die "AEM: (bogus?) root device found not encrypted!"
-    fi
+    die "AEM: (bogus?) root device found not encrypted!"
 fi
 
 for lv in $(getarg rd.lvm.lv); do
     if [ -e /dev/$lv ]; then
         devid=`lsblk -dnr -o MAJ:MIN /dev/$lv`
-        for slave in /sys/dev/block/$devid/slaves/*; do
-            if ! check_device $slave; then
-                die "AEM: (bogus?) device /dev/$lv found not encrypted!"
-            fi
-        done
+        if ! check_device /sys/dev/block/$devid; then
+            die "AEM: (bogus?) device /dev/$lv found not encrypted!"
+        fi
     fi
 done
 


### PR DESCRIPTION
This fixes the error `AEM: (bogus?) root device found not encrypted!`
when using LVM snapshots, lvmcache(7), lvmthin(7), etc.

Prior to this change, merely taking a snapshot of the root filesystem
was enough to cause AEM to halt the boot process, because LVM snapshots
work by renaming the original LV and placing another on top of it (see
examples below), and a-e-m-check-mount-devs was only checking one level.

Now, we traverse the dependency tree, checking that each branch is
backed by encrypted storage.

EXAMPLES

a. Before a snapshot is taken:

    # lsblk -sio TYPE,NAME /dev/qubes_dom0/root
    TYPE  NAME
    lvm   qubes_dom0-root
    crypt `-luks-4f5033d5-a97e-4abd-854a-648a857f2856
    part    `-sdc1
    disk      `-sdc

b. After a snapshot is taken:

    # lsblk -sio TYPE,NAME /dev/qubes_dom0/root
    TYPE  NAME
    lvm   qubes_dom0-root
    lvm   `-qubes_dom0-root-real
    crypt   `-luks-4f5033d5-a97e-4abd-854a-648a857f2856
    part      `-sdc1
    disk        `-sdc

c. A snapshot device:

    # lsblk -sio TYPE,NAME /dev/qubes_dom0/mysnap
    TYPE  NAME
    lvm   qubes_dom0-mysnap
    lvm   |-qubes_dom0-root-real
    crypt | `-luks-4f5033d5-a97e-4abd-854a-648a857f2856
    part  |   `-sdc1
    disk  |     `-sdc
    lvm   `-qubes_dom0-mysnap-cow
    crypt   `-luks-8af7d8be-3f6e-4119-8f30-0992be65487b
    part      `-sdd2
    disk        `-sdd

d. Using lvmcache(7):

    # lsblk -sio TYPE,NAME /dev/qubes_dom0/root
    TYPE  NAME
    lvm   qubes_dom0-root
    lvm   |-qubes_dom0-cache0_cmeta
    crypt | `-luks-4f5033d5-a97e-4abd-854a-648a857f2856
    part  |   `-sdc1
    disk  |     `-sdc
    lvm   |-qubes_dom0-root_corig
    crypt | `-luks-8af7d8be-3f6e-4119-8f30-0992be65487b
    part  |   `-sdd2
    disk  |     `-sdd
    lvm   `-qubes_dom0-cache0_cdata
    crypt   `-luks-4f5033d5-a97e-4abd-854a-648a857f2856
    part      `-sdc1
    disk        `-sdc