### PR TITLE
add missing SINIT warning

### DIFF
--- a/anti-evil-maid/etc/grub.d/19_linux_xen_tboot
+++ b/anti-evil-maid/etc/grub.d/19_linux_xen_tboot
@@ -150,6 +150,10 @@ EOF
 	module	/${sinit_module}
 EOF
     done
+  else
+    message="$(gettext_printf "Anti Evil Maid (AEM): Missing SINIT module!")"
+    echo	'$message'
+    gettext_printf "Anti Evil Maid (AEM): Missing SINIT module!" >&2
   fi
   sed "s/^/$submenu_indentation/" << EOF
 }


### PR DESCRIPTION
In case it is forgotten or in case file names get changed by upstream give the user a hint.

Untested.

//cc @rustybird 