### PR TITLE
add systemctl enable tcsd

### DIFF
--- a/anti-evil-maid/README
+++ b/anti-evil-maid/README
@@ -50,6 +50,7 @@ PCR-04: 93 33 4E 81 A6 9C 80 54 D6 87 C7 FD 76 7C 6F 4C 70 FC C6 73
 3) Take ownership of your TPM. This, among other things, would generate
 the TPM SRK key used for sealing process:
 
+# systemctl enable tcsd
 # systemctl restart tcsd
 # tpm_takeownership -y -z
 


### PR DESCRIPTION
Otherwise `tcsd` would not restart after reboot.
(By Fedora default, newly installed services do not get automatically enabled.)

//cc @rustybird 