### PR TITLE
-install: Always regenerate grub.cfg

### DIFF
--- a/anti-evil-maid/sbin/anti-evil-maid-install
+++ b/anti-evil-maid/sbin/anti-evil-maid-install
@@ -196,10 +196,12 @@ if replace; then
 
     log "Bind mounting $PART_MNT at $BOOT_DIR"
     mount --bind "$PART_MNT" "$BOOT_DIR"
+fi
 
-    log "Generating GRUB configuration"
-    grub2-mkconfig -o "$GRUB_CFG"
+log "Generating GRUB configuration"
+grub2-mkconfig -o "$GRUB_CFG"
 
+if replace; then
     log "Unmounting bind mounted $BOOT_DIR"
     umount "$BOOT_DIR"
 fi


### PR DESCRIPTION
This is needed for internal partitions too, in order to pick up the SINIT blob.

Closes #21