### PR TITLE
remove misleading text on write-protect switches

### DIFF
--- a/README
+++ b/README
@@ -206,7 +206,9 @@ suffixes for destroyed devices.
 
 Installation directly onto a (truly) read-only media (such as a CD-R) is not
 supported. You can, however, copy the contents of an existing RW media onto
-RO media after the initial sealing takes place. Remember to always pull
+RO media after the initial sealing takes place. Physical write-protect
+switches on USB sticks are fine (install AEM in RW mode, then
+flip the switch and proceed to use as RO media). Remember to always pull
 out the RO media when your text secret or TOTP code is displayed! Failing
 to do that will result in invalidation of freshness token in the TPM memory
 and the AEM media will fail to perform verified boot next time, falling

--- a/README
+++ b/README
@@ -206,9 +206,7 @@ suffixes for destroyed devices.
 
 Installation directly onto a (truly) read-only media (such as a CD-R) is not
 supported. You can, however, copy the contents of an existing RW media onto
-RO media after the initial sealing takes place. Physical write-protect
-switches on SD cards or USB sticks are fine (install AEM in RW mode, then
-flip the switch and proceed to use as RO media). Remember to always pull
+RO media after the initial sealing takes place. Remember to always pull
 out the RO media when your text secret or TOTP code is displayed! Failing
 to do that will result in invalidation of freshness token in the TPM memory
 and the AEM media will fail to perform verified boot next time, falling


### PR DESCRIPTION
The Anti Evil Maid README [states the following](https://github.com/QubesOS/qubes-antievilmaid/blob/7fca13e7d4e7e8b2b177801de68dbf9dcb860b12/README#L209-L211):
> Physical write-protect switches on SD cards or USB sticks are fine (install AEM in RW mode, then flip the switch and proceed to use as RO media).


This implies that SD cards' write-protect switches are in fact physically implemented, which is untrue.
In reality, these switches are implemented as a [software-based honor system](https://electronics.stackexchange.com/a/325880)—something far below the security standards of an evil-maid threat model.

I've never seen a write-protected USB drive either, so why not remove this sentence altogether?