### PR TITLE
No longer appending a newline character to the OTP URI

### DIFF
--- a/sbin/anti-evil-maid-install
+++ b/sbin/anti-evil-maid-install
@@ -213,7 +213,7 @@ if mfa && [ ! -e "$AEM_DIR/$LABEL/secret.otp" ]; then
 
     # create an ANSI text QR code and show it in the terminal
     otp_uri="otpauth://totp/${LABEL}?secret=${otp_secret}"
-    echo "$otp_uri" | qrencode -t ansiutf8
+    echo -n "$otp_uri" | qrencode -t ansiutf8
     log "Please scan the above QR code with your OTP device."
 
     # display the text form of secret to user, too


### PR DESCRIPTION
With this change it is possible to import the OTP via Barcode into Authy (23.1.1), Google Authenticator (Version 3.0.2102) and FreeOTP. Without this change the Apps issue an error stating: invalid token.
