### PR TITLE
Don't use 'dmsetup table --showkeys', it doesn't work with LUKS2

### DIFF
--- a/sbin/anti-evil-maid-install
+++ b/sbin/anti-evil-maid-install
@@ -279,10 +279,7 @@ if mfa && [ ! -e "$AEM_DIR/$LABEL/secret.key" ]; then
 
         log "Adding key file to new key slot for $devname (UUID $uuid)"
 
-        dmsetup table --showkeys luks-"$uuid" |
-        cut -d ' ' -f 5 |
-        unhex |
-        cryptsetup luksAddKey --master-key-file /dev/stdin "$dev" "$rawkey"
+        cryptsetup luksAddKey "$dev" "$rawkey"
     done
 
     log "Shredding the unencrypted key file"


### PR DESCRIPTION
LUKS2 keeps master key in kernel 'login' keyring by default. Raw key
cannot be exported from there. Instead, ask the user for the passphrase
(cryptsetup will do that).