### PR TITLE
Fix $SEAL being quoted in anti-evil-maid-seal

### DIFF
--- a/sbin/anti-evil-maid-seal
+++ b/sbin/anti-evil-maid-seal
@@ -82,7 +82,7 @@ for ext in txt key otp fre; do
          [ "$output" -nt /etc/anti-evil-maid.conf ]; then
         message "Skipped $input (already sealed)"
     elif if [ ! -t 0 ]; then cat "$SRK_PASSWORD_CACHE"; fi |
-         tpm_sealdata $Z "$SEAL" -i "$input" -o "$output"; then
+         tpm_sealdata $Z $SEAL -i "$input" -o "$output"; then
         rm -f "${output%2}"
         SEALED=$((SEALED + 1))
         message "Sealed $input using $SEAL"


### PR DESCRIPTION
This caused tpm_sealdata to fail due to unknown argument (list of PCRs).

Got broken in ee10eb9fc0012fe82e2cd24b0bae5cce355df60e.

@marmarek